### PR TITLE
Spritesheet

### DIFF
--- a/data/images/entities/robotrons_spritesheet.json
+++ b/data/images/entities/robotrons_spritesheet.json
@@ -1,0 +1,20 @@
+{"robotrons_spritesheet.json": {
+
+    "grunt":
+    {
+        "frame": {"x":0,"y":0,"w":9,"h":13},
+        "rows":1,
+        "cols":3,
+        "padding": {"x":3,"y":0}
+    },
+    "hulk":
+    {
+        "frame": {"x":0,"y":0,"w":13,"h":14},
+        "rows":3,
+        "cols":3,
+        "padding": {"x":1,"y":0}
+    }},
+    "meta": {
+        "colorKey": {"r":255,"g":255,"b":255}
+    }
+}

--- a/scripts/spritesheet.py
+++ b/scripts/spritesheet.py
@@ -1,8 +1,15 @@
 import pygame
+import json
 
 class SpriteSheet:
     def __init__(self, filename):
         self.sprite_sheet = pygame.image.load(filename).convert()
+
+        # Load the meta data for the sprite sheet
+        self.meta_data = filename.replace('png', 'json')
+        with open(self.meta_data) as f:
+            self.data = json.load(f)
+        f.close()
 
     def get_sprite(self, x, y, width, height):
         """Get a single sprite from the sprite sheet.
@@ -11,21 +18,38 @@ class SpriteSheet:
         """
 
         sprite = pygame.Surface((width, height)).convert()              # define an empty surface
-        #sprite.set_colorkey((0, 0, 0))                                 # set the color key for transparency
+        sprite.set_colorkey((255, 255, 255))                            # set the color key for transparency
         sprite.blit(self.sprite_sheet, (0, 0), (x, y, width, height))   # copy the sprite from the sprite sheet to the surface
         return sprite                                                   # return the surface
     
-    def get_sprites(self, x, y, width, height, rows, cols):
+    def get_sprites(self, x, y, width, height, rows, cols, x_padding=0, y_padding=0):
         """Get a grid of sprites from the sprite sheet.
         
         :return: List of sprite surfaces
         """
 
         # TODO: Right now this only works for a grid of same-size sprites. This may need updated if the sprites in the sheet aren't uniform in size.
-        sprites = []
+        sprites = []        
         for row in range(rows):
+            #row padding
+            if row > 0:
+                    y += y_padding
+
             for col in range(cols):
+                #column padding
+                if col > 0:
+                    x += x_padding
+
                 sprite = self.get_sprite(x + col * width, y + row * height, width, height)
                 sprites.append(sprite)
         return sprites
 
+    def parse_sprites(self, entity_name):
+        """Parse the sprite sheet for a specific entity.
+        
+        :return: List of sprite surfaces
+        """
+
+        sprite = self.data[self.meta_data.rsplit('/', 1)[1]][entity_name]
+        sprite_frame = sprite['frame']
+        return self.get_sprites(sprite_frame['x'], sprite_frame['y'], sprite_frame['w'], sprite_frame['h'], sprite['rows'], sprite['cols'], sprite['padding']['x'], sprite['padding']['y'])


### PR DESCRIPTION
## Description

Initial work to read and parse game sprite sheets for use as character rendering and animation.  The given sprite sheets use non-standard spacing and will either need mapped individually in the json, or spaced more evenly in the png file in future edits. We should decide which route we're going to take for this based on desired collision mechanics and precision.

### Example use:

```
# TODO: This spiritesheet should be passed into the entities that need it. 
self.robotron_spritesheet = SpriteSheet("data/images/entities/robotrons_spritesheet.png")

# Each entity can call parse_sprites() as part of their own init constructor 
# for independent organization of animation strips
self.grunt_sprites = self.robotron_spritesheet.parse_sprites("grunt")

# Example of blitting sprites onto the display
self.display.blit(self.grunt_sprites[0],(5, 0))
self.display.blit(self.grunt_sprites[1],(5, 20))
self.display.blit(self.grunt_sprites[2],(5, 40))
```

## Related Issues

- #21 
